### PR TITLE
Quote $PROFILE variable

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -67,15 +67,15 @@ Set-Alias -Name touch -Value "Touch-File"
 function Update-Profile {
     try {
         Write-Host "Getting local profile..."
-        $CurrentProfile = Get-Content -Path $PROFILE
+        $CurrentProfile = Get-Content -Path "$PROFILE"
         Write-Host "Getting cloud profile..."
         $CloudProfile = ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/graememeyer/WindowsPowerShell-Profile/main/Microsoft.PowerShell_profile.ps1'))
         Write-Host "Succesfully downloaded cloud profile."
         Write-Host "Updating local profile..."
-        Set-Content -Path $PROFILE -Value $CloudProfile
+        Set-Content -Path "$PROFILE" -Value $CloudProfile
         Write-Host "Reloading with new profile..."
       
-        . $PROFILE
+        . "$PROFILE"
     }
     catch {
         Write-Warning "Something went wrong."


### PR DESCRIPTION
Quote $PROFILE variable - some invocations of $PROFILE can be problematic, particularly if there are spaces in the file paths. Quoting  the variable relieves this issue.